### PR TITLE
Build wheel for simple internal distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 Set config parameters in `replogle_config.yaml`
 
 ```
- python -m eval.run_eval --adata_pred '/home/jeremys/code/state-eval/adata_pred_subset.h5ad' \
+python -m eval.run_eval --adata_pred '/home/jeremys/code/state-eval/adata_pred_subset.h5ad' \
     --adata_true '/home/jeremys/code/state-eval/adata_true_subset.h5ad' \
     --eval_config '/home/jeremys/code/state-eval/config/replogle_config.yaml'
 ```
 
 ## Install
+
+
 
 ### Rust/Cargo
 ```bash
@@ -16,6 +18,16 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 . "$HOME/.cargo/env"
 rustc --version
 cargo --version
+```
+
+### Wheel
+```bash
+# Build wheel for distribution
+pip install build
+python -m build
+
+# Install from distributed wheel file
+pip install ./dist/state_eval-0.1.12-py3-none-any.whl
 ```
 
 ### Conda Env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "state-eval"
+version = "0.1.12"
+description = "Evaluation metrics for single-cell perturbation predictions"
+readme = "README.md"
+authors = [
+    { name = "Abhinav Adduri", email = "abhinav.adduri@arcinsistute.org" },
+    { name = "Yusuf Roohani", email = "yusuf.roohani@arcinsistute.org" },
+    { name = "Noam Teyssier", email = "noam.teyssier@arcinsistute.org" },
+]
+requires-python = ">=3.10,<3.13"
+dependencies = [
+    "adjustpy>=0.1.1",
+    "igraph>=0.11.8",
+    "leidenalg>=0.10.2",
+    "ott-jax>=0.5.0",
+    "pdex>=0.1.2",
+    "pyyaml>=6.0.2",
+    "scanpy>=1.10.3",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["eval"]
+
+[dependency-groups]
+dev = ["pytest>=8.3.5", "ruff>=0.11.8"]
+
+[project.scripts]
+run_eval = "state_eval.__main__:main"


### PR DESCRIPTION
We need to leverage state-eval metric calculator within the vcc web app. Building a simple wheel file for easy internal distribution to the vcc repo. 

I know the main branch is using `uv`, but just using this simple method to avoid conflicts and unblock for now.