### PR TITLE
Parallelize real DE and pred DE computation

### DIFF
--- a/src/cell_eval/_cli/_run.py
+++ b/src/cell_eval/_cli/_run.py
@@ -97,6 +97,11 @@ def parse_args_run(parser: ap.ArgumentParser):
         help="Allow discrete data to be evaluated (usually expected to be norm-logged inputs)",
     )
     parser.add_argument(
+        "--parallel-de",
+        action="store_true",
+        help="Compute real and pred differential expression in parallel",
+    )
+    parser.add_argument(
         "--profile",
         type=str,
         default="full",
@@ -172,6 +177,7 @@ def run_evaluation(args: ap.Namespace):
                 outdir=args.outdir,
                 allow_discrete=args.allow_discrete,
                 prefix=ct,
+                parallel_de=args.parallel_de,
             )
             evaluator.compute(
                 profile=args.profile,
@@ -193,6 +199,7 @@ def run_evaluation(args: ap.Namespace):
             batch_size=args.batch_size,
             outdir=args.outdir,
             allow_discrete=args.allow_discrete,
+            parallel_de=args.parallel_de,
         )
         evaluator.compute(
             profile=args.profile,


### PR DESCRIPTION
Previously, real DEs and pred DEs were being computed sequentially, and each call took several minutes. Because their results do not depend on each other, we can parallelize the two computations.

For now, I've gated this behind a flag.

TODO: run sample eval to verify identical results to sequential process.