### PR TITLE
Add top-k accuracy metric for perturbation evaluation

### DIFF
--- a/src/cell_eval/metrics/__init__.py
+++ b/src/cell_eval/metrics/__init__.py
@@ -8,6 +8,7 @@ from ._anndata import (
     mse,
     mse_delta,
     pearson_delta,
+    top_k_accuracy,
 )
 from ._de import (
     DEDirectionMatch,
@@ -31,6 +32,7 @@ __all__ = [
     "mse_delta",
     "mae_delta",
     "discrimination_score",
+    "top_k_accuracy",
     # DE metrics
     "DEDirectionMatch",
     "DESpearmanSignificant",

--- a/src/cell_eval/metrics/_impl.py
+++ b/src/cell_eval/metrics/_impl.py
@@ -8,6 +8,7 @@ from ._anndata import (
     mse,
     mse_delta,
     pearson_delta,
+    top_k_accuracy,
 )
 from ._de import (
     DEDirectionMatch,
@@ -71,6 +72,14 @@ for distance_metric in ["l1", "l2", "cosine"]:
         func=discrimination_score,
         kwargs={"metric": distance_metric},
     )
+
+metrics_registry.register(
+    name="top_k_accuracy",
+    metric_type=MetricType.ANNDATA_PAIR,
+    description="Top-k retrieval accuracy of predicted perturbation profiles",
+    best_value=MetricBestValue.ONE,
+    func=top_k_accuracy,
+)
 
 metrics_registry.register(
     name="pearson_edistance",

--- a/tests/test_metrics_topk.py
+++ b/tests/test_metrics_topk.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+import anndata as ad
+
+from cell_eval._types import PerturbationAnndataPair
+from cell_eval.metrics import top_k_accuracy
+
+
+def _make_anndata(matrix: np.ndarray, perts: list[str], genes: list[str]) -> ad.AnnData:
+    adata = ad.AnnData(X=matrix.astype(np.float64))
+    adata.obs["pert"] = perts
+    adata.var_names = genes
+    return adata
+
+
+def _build_pair(real_matrix: np.ndarray, pred_matrix: np.ndarray) -> PerturbationAnndataPair:
+    genes = ["g1", "g2"]
+    perts = ["ctrl", "ctrl", "A", "A", "B", "B"]
+
+    adata_real = _make_anndata(real_matrix, perts, genes)
+    adata_pred = _make_anndata(pred_matrix, perts, genes)
+
+    return PerturbationAnndataPair(
+        real=adata_real,
+        pred=adata_pred,
+        pert_col="pert",
+        control_pert="ctrl",
+    )
+
+
+def test_topk_accuracy_perfect_match() -> None:
+    real_matrix = np.array(
+        [
+            [0.0, 0.0],
+            [0.1, -0.1],
+            [1.0, 0.0],
+            [1.0, 0.1],
+            [-1.0, 0.0],
+            [-1.0, -0.1],
+        ]
+    )
+
+    pred_matrix = np.array(
+        [
+            [0.0, 0.05],
+            [0.05, -0.05],
+            [1.05, 0.05],
+            [0.95, -0.05],
+            [-1.05, 0.0],
+            [-0.95, 0.05],
+        ]
+    )
+
+    pair = _build_pair(real_matrix, pred_matrix)
+
+    scores = top_k_accuracy(pair, k=1)
+
+    assert scores["A"] == pytest.approx(1.0)
+    assert scores["B"] == pytest.approx(1.0)
+
+
+def test_topk_accuracy_mismatch() -> None:
+    real_matrix = np.array(
+        [
+            [0.0, 0.0],
+            [0.1, -0.1],
+            [1.0, 0.0],
+            [1.0, 0.1],
+            [-1.0, 0.0],
+            [-1.0, -0.1],
+        ]
+    )
+
+    pred_matrix = np.array(
+        [
+            [0.0, 0.05],
+            [0.05, -0.05],
+            [1.05, 0.05],
+            [0.95, -0.05],
+            [2.0, 2.0],
+            [2.2, 1.8],
+        ]
+    )
+
+    pair = _build_pair(real_matrix, pred_matrix)
+
+    scores = top_k_accuracy(pair, k=1)
+
+    assert scores["A"] == pytest.approx(1.0)
+    assert scores["B"] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- add a reusable helper for extracting dense arrays from AnnData objects
- implement a top-k perturbation retrieval accuracy metric and register it with the metric registry
- cover the new metric with unit tests that validate perfect and mismatched predictions

## Testing
- PYTHONPATH=src pytest tests/test_metrics_topk.py
- PYTHONPATH=src pytest tests/test_eval.py::test_eval_simple

------
https://chatgpt.com/codex/tasks/task_e_68fa6647b5b483259ece41497929d398