### PR TITLE
Mitigate Missing cell-eval watermark warnings caused by oversized VCC files.

### DIFF
--- a/src/cell_eval/_cli/_prep.py
+++ b/src/cell_eval/_cli/_prep.py
@@ -244,8 +244,8 @@ def strip_anndata(
                 output_path,
                 "-C",
                 temp_dir,
-                "pred.h5ad.zst",
                 "watermark.txt",
+                "pred.h5ad.zst",
             ]
         )
 


### PR DESCRIPTION
Mitigate watermark warnings caused by oversized VCC files.

```
Invalid file: Missing cell-eval watermark. Please run file through the cell-eval prep tool.
```