### PR TITLE
fix: stabilize DE Spearman correlation floats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-eval"
-version = "0.6.6"
+version = "0.6.7"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [

--- a/src/cell_eval/metrics/_de.py
+++ b/src/cell_eval/metrics/_de.py
@@ -129,8 +129,8 @@ class DESpearmanLFC:
             )
             .agg(
                 pl.corr(
-                    pl.col(data.real.fold_change_col),
-                    pl.col(f"{data.real.fold_change_col}_pred"),
+                    pl.col(data.real.fold_change_col).cast(pl.Float64),
+                    pl.col(f"{data.real.fold_change_col}_pred").cast(pl.Float64),
                     method="spearman",
                 ).alias("spearman_corr"),
             )

--- a/tests/test_de_float_types.py
+++ b/tests/test_de_float_types.py
@@ -1,0 +1,31 @@
+import polars as pl
+
+from cell_eval._types import DEComparison, DEResults
+from cell_eval.metrics._de import DESpearmanLFC
+
+
+def test_de_spearman_lfc_mixed_float_types() -> None:
+    """Regression test: DESpearmanLFC handles mixed Float32/Float64 columns."""
+    real_df = pl.DataFrame(
+        {
+            "target": ["pert1", "pert1", "pert2", "pert2"],
+            "feature": ["gene1", "gene2", "gene1", "gene2"],
+            "fold_change": [1.5, 2.0, 0.5, 1.2],
+            "p_value": [0.01, 0.02, 0.03, 0.04],
+            "fdr": [0.01, 0.02, 0.03, 0.04],
+        }
+    )
+
+    pred_df = real_df.with_columns(
+        pl.col("fold_change").cast(pl.Float64)
+    )
+
+    comparison = DEComparison(
+        real=DEResults(real_df, name="real"),
+        pred=DEResults(pred_df, name="pred"),
+    )
+
+    result = DESpearmanLFC(fdr_threshold=0.05)(comparison)
+
+    assert isinstance(result, dict)
+    assert all(isinstance(value, (int, float)) for value in result.values())

--- a/tests/test_de_float_types.py
+++ b/tests/test_de_float_types.py
@@ -16,9 +16,7 @@ def test_de_spearman_lfc_mixed_float_types() -> None:
         }
     )
 
-    pred_df = real_df.with_columns(
-        pl.col("fold_change").cast(pl.Float64)
-    )
+    pred_df = real_df.with_columns(pl.col("fold_change").cast(pl.Float64))
 
     comparison = DEComparison(
         real=DEResults(real_df, name="real"),


### PR DESCRIPTION
Cast DE fold-change columns to Float64 at correlation time and add a regression test for mixed Float32/Float64 inputs.

With latest `cell-eval` and `python=3.12` the `de_spearman_lfc_sig` calculation failed