### PR TITLE
fix: respect CPU affinity (SLURM cgroups) when auto-detecting num_threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-eval"
-version = "0.7.1"
+version = "0.7.2"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [

--- a/src/cell_eval/_evaluator.py
+++ b/src/cell_eval/_evaluator.py
@@ -18,6 +18,19 @@ from .utils import _cast_float16_to_float32
 logger = logging.getLogger(__name__)
 
 
+def _available_cpus() -> int:
+    """Return CPUs the current process is allowed to use.
+
+    Uses ``os.sched_getaffinity`` on Linux so SLURM/cgroup/taskset limits are
+    respected; falls back to ``mp.cpu_count`` on macOS/Windows where that API
+    is unavailable (those platforms typically run locally without cgroup caps).
+    """
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return mp.cpu_count()
+
+
 class MetricsEvaluator:
     """
     Evaluates benchmarking metrics of a predicted and real anndata object.
@@ -70,6 +83,9 @@ class MetricsEvaluator:
         # Enable a global string cache for categorical columns
         pl.enable_string_cache()
 
+        if num_threads == -1:
+            num_threads = _available_cpus()
+
         if os.path.exists(outdir):
             logger.warning(
                 f"Output directory {outdir} already exists, potential overwrite occurring"
@@ -91,7 +107,7 @@ class MetricsEvaluator:
                 anndata_pair=self.anndata_pair,
                 de_pred=de_pred,
                 de_real=de_real,
-                num_threads=num_threads if num_threads != -1 else mp.cpu_count(),
+                num_threads=num_threads,
                 allow_discrete=allow_discrete,
                 outdir=outdir,
                 prefix=prefix,


### PR DESCRIPTION
## Summary                                                                                                                                                                                                         
                                                             
- Fixes [#235](https://github.com/ArcInstitute/cell-eval/issues/235): `MetricsEvaluator` crashed under SLURM (`--cpus-per-task=N`) when the host had more CPUs than the job allocation, because `mp.cpu_count()` returns host-wide CPUs and ignores cgroup/cpuset limits.  
The oversized thread count was forwarded to `numba.set_num_threads()` via `pdex`, raising `ValueError: The number of threads must be between 1 and N`.
- Replaces `mp.cpu_count()` with an affinity-aware `_available_cpus()` helper using `os.sched_getaffinity(0)`, with a `mp.cpu_count()` fallback for macOS/Windows (those platforms don't run SLURM and have no cgroup caps in practice).                                                                                                                                                                                          
- Resolves the `num_threads == -1` sentinel at the top of `MetricsEvaluator.__init__` so the resolved value is used everywhere downstream rather than only at the `_build_de_comparison` call site.
- No new dependency required — `os.sched_getaffinity` is stdlib and matches the same source numba uses internally to size its threadpool.