### PR TITLE
feat: add data ceiling (real-data upper bound) to MetricsEvaluator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ AnnData inputs (predicted + real)
 
 ### Key Abstractions
 
-- **`MetricsEvaluator`** (`src/cell_eval/_evaluator.py`) — Main programmatic entry point. Validates input AnnData objects, computes differential expression via `pdex`, and orchestrates the metric pipeline.
+- **`MetricsEvaluator`** (`src/cell_eval/_evaluator.py`) — Main programmatic entry point. Validates input AnnData objects, computes differential expression via `pdex`, and orchestrates the metric pipeline. `compute_ceiling()` estimates a per-metric data ceiling (upper bound) from the real data alone: it bootstraps each perturbation (and the control) to 2× cells, splits into two equal halves treated as real/pred, and runs the full pipeline (DE computed in-memory). Exposed via the `run --ceiling` / `--ceiling-seed` CLI flags (additive: writes `ceiling_results.csv` / `agg_ceiling_results.csv`).
 
 - **`MetricRegistry`** (`src/cell_eval/metrics/_registry.py`) — Global singleton `metrics_registry`. Metrics are registered with a name, type (`DE` or `ANNDATA_PAIR`), compute function, and best-value indicator. Supports both plain functions and class-based metrics requiring instantiation.
 
@@ -70,7 +70,7 @@ Metrics are split into two categories registered in `src/cell_eval/metrics/_impl
 
 ### CLI
 
-Subcommands in `src/cell_eval/_cli/`: `prep` (data preparation for VCC), `run` (evaluation), `baseline` (create baseline), `score` (normalize against baseline). CLI defaults are in `_cli/_const.py`.
+Subcommands in `src/cell_eval/_cli/`: `prep` (data preparation for VCC), `run` (evaluation; `--ceiling`/`--ceiling-seed` additionally emit a real-data ceiling), `baseline` (create baseline), `score` (normalize against baseline). CLI defaults are in `_cli/_const.py`.
 
 ### Test Data Utilities
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,31 @@ evaluator = MetricsEvaluator(
 
 This will give you metric evaluations for each perturbation individually (`results`) and aggregated results over all perturbations (`agg_results`).
 
+#### Data ceiling
+
+To estimate the *maximum* achievable score on each metric given the noise inherent in the real
+data, pass `--ceiling`. This is computed from the **real data only**: per perturbation (and the
+control), its cells are bootstrapped to twice their count and split into two equal halves; one
+half plays "real" and the other "prediction", and the full metric suite is run on that self-split.
+The result is, per metric, an upper bound on how well any model could score on this dataset.
+
+```bash
+cell-eval run \
+    -ap <your/path/to/pred>.h5ad \
+    -ar <your/path/to/real>.h5ad \
+    --num-threads 64 \
+    --profile full \
+    --ceiling
+```
+
+This is *additive*: it writes the normal `results.csv` / `agg_results.csv` **and**
+`ceiling_results.csv` / `agg_ceiling_results.csv`. The bootstrap is reproducible via
+`--ceiling-seed` (default `0`). From python, call `compute_ceiling` on the evaluator:
+
+```python
+ceiling, ceiling_agg = evaluator.compute_ceiling(seed=0)
+```
+
 ### Score
 
 To normalize your scores against a baseline you can run the `cell-eval score` command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-eval"
-version = "0.7.2"
+version = "0.7.3"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [

--- a/src/cell_eval/_cli/_run.py
+++ b/src/cell_eval/_cli/_run.py
@@ -97,6 +97,19 @@ def parse_args_run(parser: ap.ArgumentParser):
         help="Metrics to skip (comma-separated for multiple) (see docs for more details)",
     )
     parser.add_argument(
+        "--ceiling",
+        action="store_true",
+        help="Additionally compute a data ceiling: a real-data-only upper bound on "
+        "each metric, estimated by bootstrapping the real data against itself. "
+        "Writes ceiling_results.csv / agg_ceiling_results.csv alongside the normal results.",
+    )
+    parser.add_argument(
+        "--ceiling-seed",
+        type=int,
+        default=0,
+        help="Random seed for the data ceiling bootstrap [default: %(default)s]",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s {version}".format(
@@ -166,6 +179,14 @@ def run_evaluation(args: ap.Namespace):
                 skip_metrics=skip_metrics,
                 basename="results.csv",
             )
+            if args.ceiling:
+                evaluator.compute_ceiling(
+                    profile=args.profile,
+                    metric_configs=metric_kwargs,
+                    skip_metrics=skip_metrics,
+                    basename="ceiling_results.csv",
+                    seed=args.ceiling_seed,
+                )
 
     else:
         evaluator = MetricsEvaluator(
@@ -186,3 +207,11 @@ def run_evaluation(args: ap.Namespace):
             skip_metrics=skip_metrics,
             basename="results.csv",
         )
+        if args.ceiling:
+            evaluator.compute_ceiling(
+                profile=args.profile,
+                metric_configs=metric_kwargs,
+                skip_metrics=skip_metrics,
+                basename="ceiling_results.csv",
+                seed=args.ceiling_seed,
+            )

--- a/src/cell_eval/_evaluator.py
+++ b/src/cell_eval/_evaluator.py
@@ -2,7 +2,7 @@ import logging
 import multiprocessing as mp
 import os
 import warnings
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import anndata as ad
 import numpy as np
@@ -230,12 +230,13 @@ class MetricsEvaluator:
         pert_col = self.anndata_pair.pert_col
 
         rng = np.random.default_rng(seed)
-        labels = cast(pd.Series, real.obs[pert_col]).to_numpy(str)
 
+        # Group row positions per perturbation in a single pass (`observed=True`
+        # keeps only perturbations actually present). `.indices` yields positional
+        # indices, so they can index the AnnData directly.
         half_real_idx: list[np.ndarray] = []
         half_pred_idx: list[np.ndarray] = []
-        for pert in np.unique(labels):
-            idx = np.flatnonzero(labels == pert)
+        for _pert, idx in real.obs.groupby(pert_col, observed=True).indices.items():
             draws = rng.choice(idx, size=2 * idx.size, replace=True)
             half_real_idx.append(draws[: idx.size])
             half_pred_idx.append(draws[idx.size :])

--- a/src/cell_eval/_evaluator.py
+++ b/src/cell_eval/_evaluator.py
@@ -1,9 +1,11 @@
 import logging
 import multiprocessing as mp
 import os
-from typing import Any, Literal
+import warnings
+from typing import Any, Literal, cast
 
 import anndata as ad
+import numpy as np
 import pandas as pd
 import polars as pl
 import scanpy as sc
@@ -92,6 +94,13 @@ class MetricsEvaluator:
             )
         os.makedirs(outdir, exist_ok=True)
 
+        # Stored so the data ceiling (compute_ceiling) can reuse the exact same
+        # DE / pdex configuration as the main evaluation for comparability.
+        self._num_threads = num_threads
+        self._allow_discrete = allow_discrete
+        self._skip_de = skip_de
+        self._pdex_kwargs = pdex_kwargs or {}
+
         self.anndata_pair = _build_anndata_pair(
             real=adata_real,
             pred=adata_pred,
@@ -111,7 +120,7 @@ class MetricsEvaluator:
                 allow_discrete=allow_discrete,
                 outdir=outdir,
                 prefix=prefix,
-                pdex_kwargs=pdex_kwargs or {},
+                pdex_kwargs=self._pdex_kwargs,
             )
 
         self.outdir = outdir
@@ -139,30 +148,136 @@ class MetricsEvaluator:
         agg_results = pipeline.get_agg_results()
 
         if write_csv:
-            if self.prefix is not None:
-                self.prefix = self.prefix.replace(
-                    "/", "-"
-                )  # some prefixes (e.g. HepG2/C3A) may have slashes in them
-            if basename is not None:
-                basename = basename.replace(
-                    "/", "-"
-                )  # some basenames (e.g. HepG2/C3A_results.csv) may have slashes in them
-            outpath = os.path.join(
-                self.outdir,
-                f"{self.prefix}_{basename}" if self.prefix else basename,
-            )
-            agg_outpath = os.path.join(
-                self.outdir,
-                f"{self.prefix}_agg_{basename}" if self.prefix else f"agg_{basename}",
-            )
-
-            logger.info(f"Writing perturbation level metrics to {outpath}")
-            results.write_csv(outpath)
-
-            logger.info(f"Writing aggregate metrics to {agg_outpath}")
-            agg_results.write_csv(agg_outpath)
+            self._write_results(results, agg_results, basename)
 
         return results, agg_results
+
+    def compute_ceiling(
+        self,
+        profile: Literal["full", "vcc", "minimal", "de", "anndata", "pds"] = "full",
+        metric_configs: dict[str, dict[str, Any]] | None = None,
+        skip_metrics: list[str] | None = None,
+        basename: str = "ceiling_results.csv",
+        write_csv: bool = True,
+        break_on_error: bool = False,
+        seed: int = 0,
+    ) -> tuple[pl.DataFrame, pl.DataFrame]:
+        """Estimate a data ceiling: the maximum achievable score per metric.
+
+        Uses the real data only. For each perturbation (and the control) the
+        cells are bootstrapped to twice their count and split into two equal
+        halves; one half is treated as "real" and the other as "prediction".
+        Running the normal metric pipeline on that self-split yields, per metric,
+        an upper bound on how well any model could score given the noise inherent
+        in the real data.
+
+        Outputs mirror :meth:`compute` (``ceiling_results.csv`` /
+        ``agg_ceiling_results.csv``). The bootstrap DE is computed in-memory and
+        not written to disk. The same ``pdex_kwargs`` and ``allow_discrete`` used
+        for the main evaluation are reused so the ceiling is directly comparable.
+        """
+        logger.info(f"Computing data ceiling (seed={seed})")
+        half_real, half_pred = self._bootstrap_halves(seed)
+
+        ceiling_pair = PerturbationAnndataPair(
+            real=half_real,
+            pred=half_pred,
+            control_pert=self.anndata_pair.control_pert,
+            pert_col=self.anndata_pair.pert_col,
+            embed_key=self.anndata_pair.embed_key,
+        )
+
+        if self._skip_de:
+            ceiling_de = None
+        else:
+            ceiling_de = _build_de_comparison(
+                anndata_pair=ceiling_pair,
+                num_threads=self._num_threads,
+                allow_discrete=self._allow_discrete,
+                outdir=None,  # keep the bootstrap DE in-memory; never persisted
+                prefix=None,
+                pdex_kwargs=dict(self._pdex_kwargs),
+            )
+
+        pipeline = MetricPipeline(
+            profile=profile,
+            metric_configs=metric_configs,
+            break_on_error=break_on_error,
+        )
+        if skip_metrics is not None:
+            pipeline.skip_metrics(skip_metrics)
+        pipeline.compute_de_metrics(ceiling_de)
+        pipeline.compute_anndata_metrics(ceiling_pair)
+        results = pipeline.get_results()
+        agg_results = pipeline.get_agg_results()
+
+        if write_csv:
+            self._write_results(results, agg_results, basename)
+
+        return results, agg_results
+
+    def _bootstrap_halves(self, seed: int) -> tuple[ad.AnnData, ad.AnnData]:
+        """Build two same-size bootstrap halves of the real data.
+
+        Resampling is stratified per perturbation (including the control): each
+        group's ``n`` cells are drawn ``2n`` times with replacement and split
+        into two halves of ``n`` cells. This guarantees both halves carry every
+        perturbation plus the control with the same per-perturbation membership
+        as the real data, so the resulting ``PerturbationAnndataPair`` validates
+        and the bootstrap DE keeps the same statistical power.
+        """
+        real = self.anndata_pair.real
+        pert_col = self.anndata_pair.pert_col
+
+        rng = np.random.default_rng(seed)
+        labels = cast(pd.Series, real.obs[pert_col]).to_numpy(str)
+
+        half_real_idx: list[np.ndarray] = []
+        half_pred_idx: list[np.ndarray] = []
+        for pert in np.unique(labels):
+            idx = np.flatnonzero(labels == pert)
+            draws = rng.choice(idx, size=2 * idx.size, replace=True)
+            half_real_idx.append(draws[: idx.size])
+            half_pred_idx.append(draws[idx.size :])
+
+        # Sampling with replacement duplicates obs names; anndata warns about the
+        # non-unique index on slice, so silence that one known-benign warning and
+        # make the names unique immediately afterwards.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", message="Observation names are not unique"
+            )
+            half_real = real[np.concatenate(half_real_idx)].copy()
+            half_pred = real[np.concatenate(half_pred_idx)].copy()
+        half_real.obs_names_make_unique()
+        half_pred.obs_names_make_unique()
+
+        return half_real, half_pred
+
+    def _write_results(
+        self,
+        results: pl.DataFrame,
+        agg_results: pl.DataFrame,
+        basename: str,
+    ) -> None:
+        # some prefixes/basenames (e.g. HepG2/C3A) may have slashes in them
+        prefix = self.prefix.replace("/", "-") if self.prefix is not None else None
+        basename = basename.replace("/", "-")
+
+        outpath = os.path.join(
+            self.outdir,
+            f"{prefix}_{basename}" if prefix else basename,
+        )
+        agg_outpath = os.path.join(
+            self.outdir,
+            f"{prefix}_agg_{basename}" if prefix else f"agg_{basename}",
+        )
+
+        logger.info(f"Writing perturbation level metrics to {outpath}")
+        results.write_csv(outpath)
+
+        logger.info(f"Writing aggregate metrics to {agg_outpath}")
+        agg_results.write_csv(agg_outpath)
 
 
 def _build_anndata_pair(

--- a/src/cell_eval/metrics/_anndata.py
+++ b/src/cell_eval/metrics/_anndata.py
@@ -1,7 +1,7 @@
 """Array metrics module."""
 
 from logging import getLogger
-from typing import Callable, Literal, Sequence, cast
+from typing import Any, Callable, Literal, Sequence, cast
 
 import anndata as ad
 import numpy as np
@@ -284,7 +284,11 @@ class ClusteringAgreement:
         embed_key: str | None = None,
     ) -> ad.AnnData:
         # Isolate the features
-        feats = adata.obsm.get(embed_key, adata.X)  # type: ignore
+        # embed_key may be None; narrow it before .get (whose key must be str) and
+        # keep feats untyped since it may be a dense array or a sparse matrix.
+        feats: Any = (
+            adata.X if embed_key is None else adata.obsm.get(embed_key, adata.X)
+        )
 
         # Convert to float if not already
         if feats.dtype != np.dtype("float64"):

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -391,3 +391,169 @@ def test_eval_downsampled_cells():
         break_on_error=True,
     )
     validate_expected_files(OUTDIR)
+
+
+def _assert_results_close(a, b) -> None:
+    """Assert two per-perturbation result frames are numerically identical."""
+    a = a.sort("perturbation")
+    b = b.sort("perturbation")
+    assert sorted(a.columns) == sorted(b.columns)
+    assert a["perturbation"].to_list() == b["perturbation"].to_list()
+    cols = [c for c in a.columns if c != "perturbation"]
+    num_a = a.select(cols).to_numpy().astype(float)
+    num_b = b.select(cols).to_numpy().astype(float)
+    assert np.allclose(num_a, num_b, equal_nan=True)
+
+
+def test_ceiling_bootstrap_halves_membership():
+    """Each half must carry every perturbation + control with the real counts."""
+    adata_real = build_random_anndata()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_real.copy(),
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+        skip_de=True,  # membership only depends on the bootstrap, skip pdex
+    )
+
+    half_real, half_pred = evaluator._bootstrap_halves(seed=0)
+
+    real_counts = evaluator.anndata_pair.real.obs[PERT_COL].value_counts().to_dict()
+    assert CONTROL_VAR in real_counts
+    for half in (half_real, half_pred):
+        half_counts = half.obs[PERT_COL].value_counts().to_dict()
+        # same set of perturbations (incl. control) and same per-pert membership
+        assert half_counts == real_counts
+        # sampling with replacement must yield unique obs names
+        assert half.obs_names.is_unique
+
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling():
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+    )
+    results, agg_results = evaluator.compute_ceiling(break_on_error=True)
+    assert results.height > 0
+    assert agg_results.height > 0
+    assert os.path.exists(f"{OUTDIR}/ceiling_results.csv")
+    assert os.path.exists(f"{OUTDIR}/agg_ceiling_results.csv")
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling_prefix():
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+        prefix="arbitrary",
+    )
+    evaluator.compute_ceiling(break_on_error=True)
+    assert os.path.exists(f"{OUTDIR}/arbitrary_ceiling_results.csv")
+    assert os.path.exists(f"{OUTDIR}/arbitrary_agg_ceiling_results.csv")
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling_profiles():
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+    )
+    for profile in KNOWN_PROFILES:
+        evaluator.compute_ceiling(
+            profile=profile,
+            break_on_error=True,
+            write_csv=False,
+        )
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling_pds_skips_de():
+    """When the evaluator skips DE, the ceiling must too (no pdex, no DE files)."""
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+        skip_de=True,
+    )
+    assert evaluator.de_comparison is None
+    results, _ = evaluator.compute_ceiling(
+        profile="pds",
+        break_on_error=True,
+        write_csv=False,
+    )
+    assert results.height > 0
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling_reproducible():
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+        num_threads=1,  # deterministic reductions
+    )
+    r1, _ = evaluator.compute_ceiling(seed=7, write_csv=False, break_on_error=True)
+    r2, _ = evaluator.compute_ceiling(seed=7, write_csv=False, break_on_error=True)
+    _assert_results_close(r1, r2)
+    shutil.rmtree(OUTDIR)
+
+
+def test_eval_ceiling_does_not_clobber_de():
+    """The in-memory ceiling DE must not overwrite the main run's DE artifacts."""
+    adata_real = build_random_anndata()
+    adata_pred = adata_real.copy()
+    evaluator = MetricsEvaluator(
+        adata_pred=adata_pred,
+        adata_real=adata_real,
+        control_pert=CONTROL_VAR,
+        pert_col=PERT_COL,
+        outdir=OUTDIR,
+    )
+    evaluator.compute(break_on_error=True)
+
+    real_de_path = f"{OUTDIR}/real_de.csv"
+    pred_de_path = f"{OUTDIR}/pred_de.csv"
+    with open(real_de_path, "rb") as fh:
+        before_real = fh.read()
+    with open(pred_de_path, "rb") as fh:
+        before_pred = fh.read()
+
+    evaluator.compute_ceiling(seed=0, break_on_error=True)
+
+    with open(real_de_path, "rb") as fh:
+        assert fh.read() == before_real
+    with open(pred_de_path, "rb") as fh:
+        assert fh.read() == before_pred
+
+    # ceiling outputs exist, but no ceiling DE artifacts are written
+    assert os.path.exists(f"{OUTDIR}/ceiling_results.csv")
+    assert os.path.exists(f"{OUTDIR}/agg_ceiling_results.csv")
+    assert not os.path.exists(f"{OUTDIR}/ceiling_real_de.csv")
+    assert not os.path.exists(f"{OUTDIR}/ceiling_pred_de.csv")
+    shutil.rmtree(OUTDIR)


### PR DESCRIPTION
## Summary

Adds a **data ceiling**: a per-metric upper bound estimated from the real data alone, answering "how good could any model possibly get on this dataset?" It is computed by splitting the real data against itself and running the full metric suite on that self-split.

Exposed two ways:
- **`MetricsEvaluator.compute_ceiling(...)`** — Python API.
- **`cell-eval run --ceiling [--ceiling-seed N]`** — CLI flag.

## How it works

Per context (celltype), using only the real data:
1. For each perturbation **and the control**, its `n` cells are bootstrapped to `2n` (sampled with replacement) and split into two equal halves of `n`.
2. One half is treated as "real", the other as "prediction".
3. The full pipeline runs on that pair — including DE (recomputed in-memory via `pdex`).

Stratifying per perturbation guarantees both halves carry every perturbation + control with the real per-perturbation membership, so the `PerturbationAnndataPair` validates and DE keeps the same statistical power.

## Behavior

- **Per-context by construction**: reuses the existing per-celltype `run` loop, so each ceiling is computed within a single context (`{celltype}_ceiling_results.csv`).
- **Additive on the CLI**: writes the normal `results.csv` / `agg_results.csv` **and** `ceiling_results.csv` / `agg_ceiling_results.csv`.
- **Reproducible** via `--ceiling-seed` (default `0`).
- **In-memory bootstrap DE** (`outdir=None`) so it never clobbers the main run's `real_de.csv` / `pred_de.csv` — and emits no extra DE artifacts.
- Reuses the evaluator's `pdex_kwargs` / `allow_discrete` / `skip_de` so the ceiling is directly comparable to the main evaluation.

## Tests

New tests cover: bootstrap membership (every pert + control, real counts, unique obs names), output files + prefixing, all profiles, the skip-DE (`pds`) path, seed reproducibility, and non-clobbering of the main DE artifacts. Full suite: **39 passed**. Also manually verified end-to-end via the CLI (single-context and `--celltype-col`), plus singleton-perturbation, sparse, and `embed_key` edge cases.

## Notes / design properties

- The two halves are drawn with replacement and **may overlap** (per spec: "sample to 2× then split"), making the ceiling mildly optimistic vs a disjoint split. Easy to add a `disjoint` option later if a more conservative ceiling is wanted.
- Single draw (point estimate; moves with the seed) — a repeated-and-averaged variant slots in behind the same method if needed.

## Docs

`README.md` (new "Data ceiling" section) and `CLAUDE.md` updated.