### PR TITLE
Make pdex cpm_filter opt-in via --cpm-filter (require pdex>=0.2.5; DE defaults unchanged)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-eval"
-version = "0.7.3"
+version = "0.7.4"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "igraph>=0.11.8",
-    "pdex>=0.2.2",
+    "pdex>=0.2.5",
     "polars>=1.30.0",
     "pyyaml>=6.0.2",
     "scanpy>=1.10.3",

--- a/src/cell_eval/_cli/_run.py
+++ b/src/cell_eval/_cli/_run.py
@@ -110,6 +110,15 @@ def parse_args_run(parser: ap.ArgumentParser):
         help="Random seed for the data ceiling bootstrap [default: %(default)s]",
     )
     parser.add_argument(
+        "--cpm-filter",
+        type=float,
+        default=None,
+        help="Optional pooled-CPM floor threshold (T) forwarded to pdex: a (target, "
+        "gene) row is dropped when the gene's bulk CPM is <= T in BOTH the target and "
+        "the reference, removing the below-detection floor. OFF by default (default DE "
+        "behavior unchanged); pass e.g. 5 to enable (T is dataset-dependent).",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s {version}".format(
@@ -172,6 +181,7 @@ def run_evaluation(args: ap.Namespace):
                 allow_discrete=args.allow_discrete,
                 prefix=ct,
                 skip_de=args.profile == "pds",
+                pdex_kwargs={"cpm_filter": args.cpm_filter},
             )
             evaluator.compute(
                 profile=args.profile,
@@ -200,6 +210,7 @@ def run_evaluation(args: ap.Namespace):
             outdir=args.outdir,
             allow_discrete=args.allow_discrete,
             skip_de=args.profile == "pds",
+            pdex_kwargs={"cpm_filter": args.cpm_filter},
         )
         evaluator.compute(
             profile=args.profile,

--- a/src/cell_eval/_evaluator.py
+++ b/src/cell_eval/_evaluator.py
@@ -398,6 +398,11 @@ def _build_pdex_kwargs(
             pdex_kwargs["is_log1p"] = False
         else:
             pdex_kwargs["is_log1p"] = True
+    # Keep cell-eval's default DE behavior unchanged from pdex<0.2.5: pin epsilon=0
+    # (pdex>=0.2.5 defaults it to 1e-9) and leave the pooled-CPM floor filter OFF.
+    # Both are opt-in — enable the filter via --cpm-filter / pdex_kwargs["cpm_filter"].
+    if "epsilon" not in pdex_kwargs:
+        pdex_kwargs["epsilon"] = 0.0
     return pdex_kwargs
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -557,3 +557,48 @@ def test_eval_ceiling_does_not_clobber_de():
     assert not os.path.exists(f"{OUTDIR}/ceiling_real_de.csv")
     assert not os.path.exists(f"{OUTDIR}/ceiling_pred_de.csv")
     shutil.rmtree(OUTDIR)
+
+
+class TestCellEvalPdexDefaults:
+    """cell-eval keeps DE defaults fixed (pdex>=0.2.5 available, behavior unchanged):
+    epsilon=0 and the pooled-CPM floor filter OFF; both opt-in."""
+
+    def test_epsilon_default_zero(self):
+        from cell_eval._evaluator import _build_pdex_kwargs
+
+        k = _build_pdex_kwargs(
+            reference="non-targeting", groupby="target", threads=1, allow_discrete=False
+        )
+        assert k["epsilon"] == 0.0
+
+    def test_cpm_filter_off_by_default(self):
+        from cell_eval._evaluator import _build_pdex_kwargs
+
+        k = _build_pdex_kwargs(
+            reference="non-targeting", groupby="target", threads=1, allow_discrete=False
+        )
+        assert "cpm_filter" not in k  # off -> pdex's own default (None)
+
+    def test_cpm_filter_opt_in_kept(self):
+        from cell_eval._evaluator import _build_pdex_kwargs
+
+        k = _build_pdex_kwargs(
+            reference="non-targeting",
+            groupby="target",
+            threads=1,
+            allow_discrete=False,
+            pdex_kwargs={"cpm_filter": 5.0},
+        )
+        assert k["cpm_filter"] == 5.0
+
+    def test_epsilon_override_kept(self):
+        from cell_eval._evaluator import _build_pdex_kwargs
+
+        k = _build_pdex_kwargs(
+            reference="non-targeting",
+            groupby="target",
+            threads=1,
+            allow_discrete=False,
+            pdex_kwargs={"epsilon": 1e-9},
+        )
+        assert k["epsilon"] == 1e-9


### PR DESCRIPTION
## Summary

Make pdex's pooled-CPM floor filter **available** in cell-eval (require the fixed pdex, add a `--cpm-filter` flag) while keeping cell-eval's **default DE behavior unchanged** for now.

## Why

pdex's geometric LFC produces `±inf`/`NaN` for genes at the detection floor (zero in one group, trace-level in the other). These pinned-at-extreme values dominate the DE ranking metrics, inflating trivial baselines and penalizing raw-count model outputs. pdex `0.2.5` provides the fix (a `cpm_filter` floor + an `epsilon=1e-9` finite-guard). This PR makes that fix **opt-in** rather than changing defaults, so existing results/pipelines are unaffected until a filter threshold is explicitly chosen.

## Changes

- **Require `pdex>=0.2.5`** (was `>=0.2.2`) so the `cpm_filter` is available.
- **Keep default DE behavior fixed:** in `_build_pdex_kwargs`, pin **`epsilon=0.0`** by default (pdex `0.2.5` would otherwise default it to `1e-9`) and leave the **`cpm_filter` OFF** by default. Both are opt-in.
- **New `--cpm-filter` CLI flag** (off by default) on `cell-eval run`; pass e.g. `--cpm-filter 5` to enable the floor (`T` is dataset-dependent). Also settable via `pdex_kwargs`.
- Bump cell-eval `0.7.3 → 0.7.4`.
- Tests: `epsilon=0` default, filter off by default, and opt-in/override behavior.

## Net effect

- **Default `cell-eval run`** computes DE exactly as before (epsilon=0, no filter) — no change to existing results.
- Users can now opt into the floor filter (`--cpm-filter 5`) and/or the finite-guard (`pdex_kwargs={"epsilon": 1e-9}`) when they want the artifact removed.
