### PR TITLE
Revert accidental 0.8.0 release bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cell-eval"
-version = "0.8.0"
+version = "0.7.3"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [
@@ -11,7 +11,7 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "igraph>=0.11.8",
-    "pdex>=0.2.5",
+    "pdex>=0.2.2",
     "polars>=1.30.0",
     "pyyaml>=6.0.2",
     "scanpy>=1.10.3",


### PR DESCRIPTION
## Summary
- Revert 211b894, the accidental 0.8.0 version bump release commit.
- Restore pyproject.toml to the pre-release 0.7.3 / pdex>=0.2.2 state so #240 can merge cleanly.

## Follow-up sequence
1. Merge this PR into main.
2. Merge #240, which bumps cell-eval to 0.7.4 and keeps the pdex fix opt-in.
3. Delete the mistaken v0.8.0 GitHub release and tag.

## Verification
- On a temporary local branch, cherry-picked #240 after this revert and confirmed final pyproject.toml is version 0.7.4 with pdex>=0.2.5.
- uv run pytest tests/test_eval.py -q: 31 passed.