### PR TITLE
Publish 0.8.1 recovery release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "cell-eval"
-version = "0.7.4"
+version = "0.8.1"
 description = "Evaluation metrics for single-cell perturbation predictions"
 readme = "README.md"
 authors = [
     { name = "Noam Teyssier", email = "noam.teyssier@arcinstitute.org" },
     { name = "Abhinav Adduri", email = "abhinav.adduri@arcinstitute.org" },
+    { name = "Leon Hafner", email = "leon.hafner@arcinstitute.org" },
     { name = "Yusuf Roohani", email = "yusuf.roohani@arcinstitute.org" },
 ]
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump package metadata from 0.7.4 to 0.8.1 so PyPI installs resolve to a fixed release above the accidental 0.8.0.
- Add Leon Hafner to the package authors.

## Why
The accidental 0.8.0 release was already uploaded to PyPI and cannot currently be yanked without PyPI project-owner access. Publishing 0.7.4 does not supersede 0.8.0 for unconstrained installs because 0.8.0 remains the highest available version. This recovery release publishes the corrected current main code as 0.8.1.

## Verification
- uv run pytest tests/test_eval.py -q: 31 passed.
- uv build: successfully built dist/cell_eval-0.8.1.tar.gz and dist/cell_eval-0.8.1-py3-none-any.whl.
- Inspected sdist/wheel metadata: Version is 0.8.1 and Author-email includes Leon Hafner.

## Follow-up
After merge, create and publish GitHub release v0.8.1 from main so the existing release workflow uploads the fixed package to PyPI.