### PR TITLE
Add `--epsilon` flag to `cell-eval run`

### DIFF
--- a/src/cell_eval/_baseline.py
+++ b/src/cell_eval/_baseline.py
@@ -77,7 +77,7 @@ def build_base_mean_adata(
 
     if output_path is not None:
         logger.info(f"Saving baseline data to {output_path}")
-        baseline_adata.write_h5ad(output_path)  # ty: ignore[invalid-argument-type]
+        baseline_adata.write_h5ad(output_path)
 
     if output_de_path is not None:
         logger.info("Calculating differential expression")

--- a/src/cell_eval/_cli/_prep.py
+++ b/src/cell_eval/_cli/_prep.py
@@ -226,7 +226,7 @@ def strip_anndata(
 
         # Write the h5ad file
         logger.info(f"Writing h5ad output to {tmp_h5ad}")
-        minimal.write_h5ad(tmp_h5ad)  # ty: ignore[invalid-argument-type]
+        minimal.write_h5ad(tmp_h5ad)
 
         # Zstd compress the h5ad file (will create pred.h5ad.zst)
         logger.info(f"Zstd compressing {tmp_h5ad}")

--- a/src/cell_eval/_cli/_run.py
+++ b/src/cell_eval/_cli/_run.py
@@ -2,6 +2,7 @@ import argparse as ap
 import importlib.metadata
 import logging
 import os
+from typing import Any
 
 from .. import KNOWN_PROFILES
 from ._const import DEFAULT_CTRL, DEFAULT_OUTDIR, DEFAULT_PERT_COL
@@ -119,6 +120,14 @@ def parse_args_run(parser: ap.ArgumentParser):
         "behavior unchanged); pass e.g. 5 to enable (T is dataset-dependent).",
     )
     parser.add_argument(
+        "--epsilon",
+        type=float,
+        default=0.0,
+        help="Epsilon (pseudocount) forwarded to pdex for the log fold-change "
+        "denominator [default: %(default)s]. Pass e.g. 1e-9 to match pdex>=0.2.5 "
+        "behavior.",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version="%(prog)s {version}".format(
@@ -154,6 +163,12 @@ def run_evaluation(args: ap.Namespace):
 
     skip_metrics = args.skip_metrics.split(",") if args.skip_metrics else None
 
+    # DE knobs forwarded to pdex (cpm_filter off by default; epsilon default 0.0).
+    pdex_kwargs: dict[str, Any] = {
+        "cpm_filter": args.cpm_filter,
+        "epsilon": args.epsilon,
+    }
+
     if args.celltype_col is not None:
         real = ad.read_h5ad(args.adata_real)
         pred = ad.read_h5ad(args.adata_pred)
@@ -181,7 +196,7 @@ def run_evaluation(args: ap.Namespace):
                 allow_discrete=args.allow_discrete,
                 prefix=ct,
                 skip_de=args.profile == "pds",
-                pdex_kwargs={"cpm_filter": args.cpm_filter},
+                pdex_kwargs=pdex_kwargs,
             )
             evaluator.compute(
                 profile=args.profile,
@@ -210,7 +225,7 @@ def run_evaluation(args: ap.Namespace):
             outdir=args.outdir,
             allow_discrete=args.allow_discrete,
             skip_de=args.profile == "pds",
-            pdex_kwargs={"cpm_filter": args.cpm_filter},
+            pdex_kwargs=pdex_kwargs,
         )
         evaluator.compute(
             profile=args.profile,

--- a/tutorials/vcc/vcc.ipynb
+++ b/tutorials/vcc/vcc.ipynb
@@ -259,7 +259,7 @@
    "id": "386ee994",
    "metadata": {},
    "outputs": [],
-   "source": "adata.write_h5ad(\"./example.h5ad\")  # ty: ignore[invalid-argument-type]"
+   "source": "adata.write_h5ad(\"./example.h5ad\")"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## What
Adds an `--epsilon` flag to `cell-eval run` that forwards a pseudocount to pdex for the log fold-change denominator.

## Why
Epsilon is currently pinned to `0.0` internally with no CLI override. Exposing it lets users pass e.g. `1e-9` (matching `pdex>=0.2.5` behavior) to avoid unstable / divide-by-zero log fold-changes when a gene's reference mean is 0.

## Details
- New `--epsilon` argument, `type=float`, **`default=0.0`** — no behavior change for existing invocations.
- Forwarded via `pdex_kwargs` to both the `--celltype-col` split path and the single-evaluator path, so it also reaches the data-ceiling DE (mirrors how `--cpm-filter` is handled).

## Also (CI fix)
Drops three now-unused `# ty: ignore[invalid-argument-type]` suppressions (`src/cell_eval/_baseline.py`, `src/cell_eval/_cli/_prep.py`, `tutorials/vcc/vcc.ipynb`). A newer `ty` no longer reports `invalid-argument-type` on `AnnData.write_h5ad`, so these were failing the `typing` job as `unused-ignore-comment`. Pure comment removals, no functional change.

## Test plan
- [x] `cell-eval run --help` shows `--epsilon` with `[default: 0.0]`
- [x] `ruff format --check`, `ruff check`, `ty check` all pass locally

> **Versioning:** no version bump in this PR — this repo bumps versions in dedicated release commits, so it's intentionally left to the maintainer's release process.
